### PR TITLE
Not working for movies with 'YYYY - title of movie' format -- fix

### DIFF
--- a/Extensions/StringExtensions.cs
+++ b/Extensions/StringExtensions.cs
@@ -74,5 +74,24 @@ namespace RenamerCore.Extensions
             // Drop the last word.
             return string.Join(" ", words.Take(words.Length - 1));
         }
+
+        /// <summary>
+        /// Returns a new string that matches the input string, but with the first word removed.
+        /// If there is only one word, then an empty string is returned.
+        /// </summary>
+        /// <param name="str"></param>
+        /// <returns></returns>
+        public static string DropFirstWord(this string str)
+        {
+            // Split the string into words
+            var words = (str ?? string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            // If we only have 1 word, return nothing as we can't do any more.
+            if (words.Length <= 1)
+                return string.Empty;
+
+            // Drop the first word.
+            return string.Join(" ", words.Skip(1));
+        }
     }
 }

--- a/Services/MovieRenamerService.cs
+++ b/Services/MovieRenamerService.cs
@@ -105,7 +105,7 @@ namespace RenamerCore.Services
             catch { }
 
             //check if the title has [year - title] format. (1900 - 2099)
-            string pattern = @"^[1,2]{1}[9,0]{1}\d{2}\s.+";
+            string pattern = @"^[1,2]{1}[9,0]{1}\d{2}\s{1,}[A-Z,a-z]+.*";
             RegexOptions options = RegexOptions.Singleline;
             Match m = Regex.Match(name, pattern, options);
             if(m.Success){

--- a/Services/MovieRenamerService.cs
+++ b/Services/MovieRenamerService.cs
@@ -109,6 +109,8 @@ namespace RenamerCore.Services
             RegexOptions options = RegexOptions.Singleline;
             Match m = Regex.Match(name, pattern, options);
             Boolean foundYearFormat = m.Success;
+            _console.WriteLine(m.Value);
+            _console.WriteLine(m.Success);
             if(foundYearFormat){
                 return await FindMovieRecursiveAsync(name.DropFirstWord());
             }else{

--- a/Services/MovieRenamerService.cs
+++ b/Services/MovieRenamerService.cs
@@ -105,13 +105,10 @@ namespace RenamerCore.Services
             catch { }
 
             //check if the title has [year - title] format. (1900 - 2099)
-            string pattern = @"^[1,2]{1}[9,0]{1}\d{2}\s\-\s.+";
+            string pattern = @"^[1,2]{1}[9,0]{1}\d{2}\s.+";
             RegexOptions options = RegexOptions.Singleline;
             Match m = Regex.Match(name, pattern, options);
-            Boolean foundYearFormat = m.Success;
-            _console.WriteLine(m.Value);
-            _console.WriteLine(m.Success);
-            if(foundYearFormat){
+            if(m.Success){
                 return await FindMovieRecursiveAsync(name.DropFirstWord());
             }else{
                 

--- a/Services/MovieRenamerService.cs
+++ b/Services/MovieRenamerService.cs
@@ -104,7 +104,17 @@ namespace RenamerCore.Services
             }
             catch { }
 
-            return await FindMovieRecursiveAsync(name.DropLastWord());
+            //check if the title has [year - title] format. (1900 - 2099)
+            string pattern = @"^[1,2]{1}[9,0]{1}\d{2}\s\-\s.+";
+            RegexOptions options = RegexOptions.Singleline;
+            Match m = Regex.Match(name, pattern, options);
+            Boolean foundYearFormat = m.Success;
+            if(foundYearFormat){
+                return await FindMovieRecursiveAsync(name.DropFirstWord());
+            }else{
+                
+                return await FindMovieRecursiveAsync(name.DropLastWord());
+            }
         }
 
         private string GetNewFileName(Movie movie, string oldFileName, string ext)


### PR DESCRIPTION
I used this program te rename my movies and the movies that started with a year didnt get matched or incorrectly matched.

example:  `:~$ renamer m --verbose`
```txt
1967 - The Jungle Book.avi =>
                * Searching for: "1967  The Jungle Book"
                * Searching for: "1967 The Jungle"
                * Searching for: "1967 The"
        Glasgow 1967 The Lisbon Lions (2017).avi
```

After my addition, it does this. Which works for me.
```txt
1967 - The Jungle Book.avi =>
                * Searching for: "1967  The Jungle Book"
                * Searching for: "The Jungle Book"
                * Searching for: "The Jungle"
        The Jungle Book (1967).avi
```

- added `DropFirstWord` in Extensions\StringExtensions
- edited `FindMovieRecursiveAsync` in Services\MovieRenamerService